### PR TITLE
Change Salamander billing to per second

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This repository contains information about service providers who host GPUs in th
 | [Lambda Labs](https://lambdalabs.com/)                                            | -                    | K80                                          | Per hour | 24-Aug-18        |
 | [Valohai](https://valohai.com/)                                            | -                    | V100, K80                                          | Per second | 24-Aug-18        |
 | [VScaler](https://www.vscaler.com/)                                            | [1GPU for a week](https://www.vscaler.com/free-gpu-cloud-trial/)                    | V100                                          | Not sure! | 29-Aug-18        |
-| [Salamander](https://salamander.ai/)                                            |                     | V100, K80                                          | Per hour | 31-Aug-18        |
+| [Salamander](https://salamander.ai/)                                            |                     | V100, K80                                          | Per second | 31-Aug-18        |
 ---
 
 ## Cloud Credits


### PR DESCRIPTION
Although the prices are displayed in hours, Salamander doesn't charge people for the entire hour if they just use a few minutes - that'd be totally unfair!

Thanks for adding Salamander to the list ^_^

Would you be open to including more pricing info as suggested by Mario on the fastai forum? [http://forums.fast.ai/t/salamander-aws-spot-instances-made-easy/21634/15](http://forums.fast.ai/t/salamander-aws-spot-instances-made-easy/21634/15)