### PR TITLE
Add pricing to all providers & more info for each GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,88 +1,85 @@
-Cloud GPU Vendors
-=================
+# Cloud GPU Vendors
 
-This repository contains information about service providers who host GPUs in the cloud for on-demand use for Machine Learning practitioners. This guide is also designed to help enthusiasts, new-comers to this field and also experienced folks to keep a track of new updates made by all these vendors and keep their costs low when deciding to choose their preferred platform.
+This repository contains information about service providers who host GPUs in
+the cloud for on-demand use for Machine Learning practitioners. This guide is
+also designed to help enthusiasts, new-comers to this field and also experienced
+folks to keep a track of new updates made by all these vendors and keep their
+costs low when deciding to choose their preferred platform.
 
 ## Cloud GPU Vendors
 
-| GPU Cloud Provider                                                                              | Free Tier                  | Top 3 GPUs                                         | Billing   | Last Updated | 
-|---------------------------------------------------------------------------------------|----------------------------|----------------------------------------------------|------------|-----------------| 
-| [Amazon Web Services (AWS)](https://aws.amazon.com/ec2/instance-types/p2/)                                  | -                          | V100, K80                                        | Per minute | 9-Aug-18        | 
-| [Google Cloud Platform (GCP)](https://cloud.google.com/gpu/)                                                   | 300$ free credit          | V100, P100, P4                                   | Per second | 9-Aug-18        | 
-| **[Google Colaboratory](https://colab.research.google.com/)**                                    | Unlimited (12 hours block) | K80                                                | **Free**       | 9-Aug-18        | 
-| **[Kaggle Kernels](https://www.kaggle.com/dansbecker/running-kaggle-kernels-with-a-gpu)** | Unlimited (6 hours block)  | K80                                                | **Free**       | 9-Aug-18        | 
-| [Microsoft Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-gpu)    | [100$ credit for students](https://azure.microsoft.com/en-in/free/students/)            | V100, P100, M60                                  | Per second | 9-Aug-18        | 
-| [Nvidia Cloud](https://www.nvidia.com/en-us/data-center/gpu-cloud-computing/)         | -                          | DGX2, DGX1, V100                                 | Not clear! | 9-Aug-18        | 
-| [Oracle Cloud](https://cloud.oracle.com/compute/gpu/features)                         | -                          | V100, P100                                       | Per hour   | 9-Aug-18        | 
-| [IBM Cloud](https://www.ibm.com/cloud/gpu)                                            | 60 days 50% off.           | V100, P100, M60                                  | Per hour   | 9-Aug-18        | 
-| [Paperspace](https://www.paperspace.com/)                                             | -                          | V100, P6000, P100                                | Per hour   | 9-Aug-18        | 
-| [FloydHub](https://www.floydhub.com/)                                                 | 1 job with 10GB storage    | V100, K80                                        | Per second | 9-Aug-18        | 
-| [Crestle](https://www.crestle.com/)                                                   | -                          | K80                                                | Per second | 9-Aug-18        | 
-| [Vector Dash](https://vectordash.com/)                                                | -                          | Titan V, 1080Ti, Titan X                         | Per second | 9-Aug-18        | 
-| [Snark AI](https://snark.ai/)                                                         | 4 hours of 1080            | 1080, 1070, P106                                 | Per hour   | 9-Aug-18        | 
-| [Clusterone](https://clusterone.com/)                                                 | -                          | Not clear!                                         | Not clear! | 9-Aug-18        | 
-| [Vast.AI](https://vast.ai/)                                                           | -                          | V100, 1080Ti, P100                               | Per hour   | 9-Aug-18        | 
-| [LeaderGPU](https://www.leadergpu.com/)                                               | -                          | V100, 1080Ti, 1080                               | Per minute | 9-Aug-18        | 
-| [GPUEater](https://gpueater.com/)                                                     | -                          | Radeon Vega Frontier, Radeon Vega 56, Radeon 580 | Per second | 9-Aug-18        | 
-| [Exoscale](https://exoscale.com/)                                                     | -                          | P100                                               | Per minute | 9-Aug-18        |
-| [DeepCognition](https://deepcognition.ai/)                                            | 2 hours                    | V100, K80                                          | Per hour | 12-Aug-18        |
-| [Alibaba Cloud](https://www.alibabacloud.com/product/gpu?spm=a3c0i.11728334.1144220.1.23794a1clKeiCs)                                            | -                    | V100, P4, P100                                          | Per hour | 14-Aug-18        | 
-| [Spell](https://spell.run/)                                            | -                    | V100, K80                                          | Per second | 17-Aug-18        |
-| [Ovh](https://www.ovh.com/world/public-cloud/instances/prices/)                                            | -                    | 1080Ti, 1070                                          | Per hour | 20-Aug-18        |
-| [Riseml](https://riseml.com/)                                            | -                    | V100                                          | Per minute | 20-Aug-18        |
-| [Neptune ML](https://neptune.ml/)                                            | 5$ credit                    | P100, K80                                          | Per hour | 22-Aug-18        |
-| [Lambda Labs](https://lambdalabs.com/)                                            | -                    | K80                                          | Per hour | 24-Aug-18        |
-| [Valohai](https://valohai.com/)                                            | -                    | V100, K80                                          | Per second | 24-Aug-18        |
-| [VScaler](https://www.vscaler.com/)                                            | [1GPU for a week](https://www.vscaler.com/free-gpu-cloud-trial/)                    | V100                                          | Not sure! | 29-Aug-18        |
-| [Salamander](https://salamander.ai/)                                            |                     | V100, K80                                          | Per second | 31-Aug-18        |
----
+- "-" means not available
+- "???" means maybe available
+- GPU prices are per hour
+- Storage prices are per GB/month
 
-## Cloud Credits
+| GPU Cloud Provider                                                                                    | K80 Price | V100 Price | Storage Price | Last Updated |
+| ----------------------------------------------------------------------------------------------------- | --------- | ---------- | ------------- | ------------ |
+| [Amazon Web Services (AWS)](https://aws.amazon.com/ec2/instance-types/p2/)                            | $0.90     | $3.06      | $0.10         | 8-Sep-18     |
+| [Google Cloud Platform (GCP)](https://cloud.google.com/gpu/)                                          | $1.21     | $3.24      | $0.03         | 8-Sep-18     |
+| [Google Collaboratory](https://colab.research.google.com/)                                            | Free      | -          | 15GB max      | 8-Sep-18     |
+| [Kaggle Kernels](https://www.kaggle.com/dansbecker/running-kaggle-kernels-with-a-gpu)                 | Free      | -          | 8GB max       | 8-Sep-18     |
+| [Salamander](https://salamander.ai/)                                                                  | $0.36     | $1.17      | $0.10         | 8-Sep-18     |
+| [Paperspace](https://www.paperspace.com/)                                                             | $0.59     | $2.30      | $0.10         | 8-Sep-18     |
+| [Oracle Cloud](https://cloud.oracle.com/compute/gpu/features)                                         | -         | $2.25      | $0.04         | 8-Sep-18     |
+| [Vast.AI](https://vast.ai/)                                                                           | $0.64     | $2.67      | -             | 8-Sep-18     |
+| [Spell](https://spell.run/)                                                                           | $0.27     | $3.06      | ???           | 8-Sep-18     |
+| [Crestle](https://www.crestle.com/)                                                                   | $0.59     | -          | $0.39         | 8-Sep-18     |
+| [Neptune ML](https://neptune.ml/)                                                                     | $0.64     | -          | $0.28         | 8-Sep-18     |
+| [Microsoft Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-gpu)          | $0.87     | $2.95      | $0.10         | 8-Sep-18     |
+| [LeaderGPU](https://www.leadergpu.com/)                                                               | -         | $3.00      | $0.13         | 8-Sep-18     |
+| [DeepCognition](https://deepcognition.ai/)                                                            | $0.90     | $3.06      | ???           | 8-Sep-18     |
+| [FloydHub](https://www.floydhub.com/)                                                                 | $1.20     | $4.20      | 100GB max     | 8-Sep-18     |
+| [IBM Cloud](https://www.ibm.com/cloud/gpu)                                                            | $2.65     | -          | ???           | 8-Sep-18     |
+| [Riseml](https://riseml.com/)                                                                         | -         | ???        | ???           | 8-Sep-18     |
+| [Alibaba Cloud](https://www.alibabacloud.com/product/gpu?spm=a3c0i.11728334.1144220.1.23794a1clKeiCs) | -         | ???        | ???           | 8-Sep-18     |
+| [Lambda Labs](https://lambdalabs.com/)                                                                | -         | ???        | ???           | 8-Sep-18     |
+| [Nvidia Cloud](https://www.nvidia.com/en-us/data-center/gpu-cloud-computing/)                         | ???       | ???        | ???           | 8-Sep-18     |
+| [Valohai](https://valohai.com/)                                                                       | ???       | ???        | ???           | 8-Sep-18     |
+| [VScaler](https://www.vscaler.com/)                                                                   | ???       | ???        | ???           | 8-Sep-18     |
 
-A lot of beginners are interested in trying these platforms for their hobby project, take it for a spin and choose the platform of their choice. Vendors also provide promo codes to let newcomers try their platform. Various online courses also provide cloud credits for their students. This section will keep posting new sources of credits for the benefit of everyone.
+### Other GPUs
 
-P.S: Incase there are other avenues for cloud credits, please raise a PR and update this section.
+| GPU Cloud Provider                                                                                    | P100 Price | GTX 1080 Price | Storage Price | Last Updated |
+| ----------------------------------------------------------------------------------------------------- | ---------- | -------------- | ------------- | ------------ |
+| [Snark AI](https://snark.ai/)                                                                         | $0.10      | -              | ???           | 8-Sep-18     |
+| [Vast.AI](https://vast.ai/)                                                                           | $1.65      | $0.10          | -             | 8-Sep-18     |
+| [Oracle Cloud](https://cloud.oracle.com/compute/gpu/features)                                         | $1.28      | -              | $0.04         | 8-Sep-18     |
+| [Vector Dash](https://vectordash.com/)                                                                | -          | $0.51          | ???           | 8-Sep-18     |
+| [LeaderGPU](https://www.leadergpu.com/)                                                               | $1.50      | $0.75          | $0.13         | 8-Sep-18     |
+| [Paperspace](https://www.paperspace.com/)                                                             | $1.72      | -              | $0.10         | 8-Sep-18     |
+| [Microsoft Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-gpu)          | $2.00      | -              | $0.13         | 8-Sep-18     |
+| [Ovh](https://www.ovh.com/world/public-cloud/instances/prices/)                                       | -          | $1.15          | $0.09         | 8-Sep-18     |
+| [Neptune ML](https://neptune.ml/)                                                                     | $2.15      | -              | $0.28         | 8-Sep-18     |
+| [Google Cloud Platform (GCP)](https://cloud.google.com/gpu/)                                          | $2.22      | -              | $0.03         | 8-Sep-18     |
+| [IBM Cloud](https://www.ibm.com/cloud/gpu)                                                            | ???        | -              | ???           | 8-Sep-18     |
+| [Exoscale](https://exoscale.com/)                                                                     | ???        | -              | ???           | 8-Sep-18     |
+| [Alibaba Cloud](https://www.alibabacloud.com/product/gpu?spm=a3c0i.11728334.1144220.1.23794a1clKeiCs) | ???        | -              | ???           | 8-Sep-18     |
 
-**Update (August 17, 2018):**
-- 20$ of credit (~100 hours of GPU compute) for [fastai](https://course.fast.ai) students by [Vast.ai](https://vast.ai/). Check their announcement [here](http://forums.fast.ai/t/vast-ai-easy-docker-based-peer-gpu-rental-training-costs-3x-to-5x-less-plus-100-200-hours-of-credit-for-fast-ai-students/20919).
+## Notes
 
-**Update (August 12, 2018):**
-- 2 hours of free trial on [DeepCognition](https://deepcognition.ai/).
+Google Cloud Platform gives you
+[$300 free compute credits](https://cloud.google.com/free/)
 
-**Update (August 10, 2018):**
-- 75-150$ AWS credits for students with [GitHub Education Pack](https://education.github.com/pack). You would need a *.edu* student email address.
+Azure gives
+[100$ free compute credits](https://azure.microsoft.com/en-in/free/students/)
+for students
 
-**Update (August 2, 2018):**
-- 42 hours of 1080 GPU credits by [Snark AI](https://snark.ai) for [fastai](https://course.fast.ai) students. Promo Code available on [fastai forums](http://forums.fast.ai/t/free-gpu-credits-for-fast-ai-courses/20183).
+Google Collaboratory, Kaggle Kernels & Crestle are only for Jupyter Notebooks
+and limited to 6/12/24 hour sessions
 
-**Update (July 6, 2018):**
-- 100 hours of GPU give away by [FloydHub](https://www.floydhub.com) to the folks at RemoteML. Check out their [tweet](https://twitter.com/remoteML/status/1015058652263153664) to participate.
+The prices for Google Cloud Platform assume you've attached the GPUs to a
+"n1-standard-16" instance.
 
-**Update (May 8, 2018):**
-- 15$ credit in [PaperSpace](https://www.paperspace.com) for [fastai](https://course.fast.ai) students. Credit Code available [here](https://github.com/asiedubrempong/fastai_deeplearn_part1/blob/master/tools/paperspace.md#summary-of-charges).
+250GB Paperspace volumes are $0.04 per GB; larger or smaller volumes cost more
 
-**Update (June, 2018):**
-- [Kaggle](https://www.kaggle.com) announces [UNLIMITED FREE Access](https://www.kaggle.com/dansbecker/running-kaggle-kernels-with-a-gpu) to a K80 GPU on their Kaggle Kernels platform. The GPU instances time out every 6 hours after but you could restart any number of times.
+## GPU Datasheets
 
+Nvidia manufactures all the GPUs listed here
 
-# Appendix for beginners
-
-## GPUs and their Manufacturers
-
-| GPU                  | Manufacturer | 
-|----------------------|--------| 
-| V100                 | Nvidia | 
-| 1080Ti               | Nvidia | 
-| 1080                 | Nvidia | 
-| P6000                | Nvidia | 
-| P5000                | Nvidia | 
-| M60                  | Nvidia | 
-| K80                  | Nvidia | 
-| P4                   | Nvidia | 
-| DGX2                 | Nvidia | 
-| DGX1                 | Nvidia | 
-| Titan X              | Nvidia | 
-| Radeon Vega Frontier | AMD    | 
-| Radeon Vega 56       | AMD    | 
-| Radeon 580           | AMD    | 
-
+| GPU                                                                                                                        | TFlops (double / single precision) | Manufacturer |
+| -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ------------ |
+| [K80](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/tesla-product-literature/TeslaK80-datasheet.pdf)      | 1.9 / 5.6                          | Nvidia       |
+| [V100](https://images.nvidia.com/content/technologies/volta/pdf/tesla-volta-v100-datasheet-letter-fnl-web.pdf)             | 7.8 / 125.0                        | Nvidia       |
+| [P100](https://images.nvidia.com/content/tesla/pdf/nvidia-tesla-p100-datasheet.pdf)                                        | 5.3 / 10.6                         | Nvidia       |
+| [GTX 1080](https://international.download.nvidia.com/geforce-com/international/pdfs/GeForce_GTX_1080_Whitepaper_FINAL.pdf) | 8.8 / 8.8                          | Nvidia       |

--- a/README.md
+++ b/README.md
@@ -13,30 +13,30 @@ costs low when deciding to choose their preferred platform.
 - GPU prices are per hour
 - Storage prices are per GB/month
 
-| GPU Cloud Provider                                                                                    | K80 Price | V100 Price | Storage Price | Last Updated |
-| ----------------------------------------------------------------------------------------------------- | --------- | ---------- | ------------- | ------------ |
-| [Google Collaboratory](https://colab.research.google.com/)                                            | Free      | -          | 15GB max      | 8-Sep-18     |
-| [Kaggle Kernels](https://www.kaggle.com/dansbecker/running-kaggle-kernels-with-a-gpu)                 | Free      | -          | 8GB max       | 8-Sep-18     |
-| [Salamander](https://salamander.ai/)                                                                  | $0.36     | $1.17      | $0.10         | 8-Sep-18     |
-| [Paperspace](https://www.paperspace.com/)                                                             | $0.59     | $2.30      | $0.10         | 8-Sep-18     |
-| [Vast.AI](https://vast.ai/)                                                                           | $0.64     | $2.30      | -             | 19-Sep-18    |
-| [Oracle Cloud](https://cloud.oracle.com/compute/gpu/features)                                         | -         | $2.25      | $0.04         | 8-Sep-18     |
-| [Spell](https://spell.run/)                                                                           | $0.27     | $3.06      | ???           | 8-Sep-18     |
-| [Crestle](https://www.crestle.com/)                                                                   | $0.59     | -          | $0.42         | 8-Sep-18     |
-| [Neptune ML](https://neptune.ml/)                                                                     | $0.64     | -          | $0.28         | 8-Sep-18     |
-| [Microsoft Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-gpu)          | $0.87     | $2.95      | $0.10         | 8-Sep-18     |
-| [LeaderGPU](https://www.leadergpu.com/)                                                               | -         | $3.00      | $0.13         | 8-Sep-18     |
-| [Amazon Web Services (AWS)](https://aws.amazon.com/ec2/instance-types/p2/)                            | $0.90     | $3.06      | $0.10         | 8-Sep-18     |
-| [DeepCognition](https://deepcognition.ai/)                                                            | $0.90     | $3.06      | ???           | 8-Sep-18     |
-| [Google Cloud Platform (GCP)](https://cloud.google.com/gpu/)                                          | $1.21     | $3.24      | $0.03         | 8-Sep-18     |
-| [FloydHub](https://www.floydhub.com/)                                                                 | $1.20     | $4.20      | 100GB max     | 8-Sep-18     |
-| [IBM Cloud](https://www.ibm.com/cloud/gpu)                                                            | $2.65     | -          | ???           | 8-Sep-18     |
-| [Alibaba Cloud](https://www.alibabacloud.com/product/gpu?spm=a3c0i.11728334.1144220.1.23794a1clKeiCs) | -         | ???        | ???           | 8-Sep-18     |
-| [Lambda Labs](https://lambdalabs.com/)                                                                | -         | ???        | ???           | 8-Sep-18     |
-| [Nvidia Cloud](https://www.nvidia.com/en-us/data-center/gpu-cloud-computing/)                         | ???       | ???        | ???           | 8-Sep-18     |
-| [Riseml](https://riseml.com/)                                                                         | -         | ???        | ???           | 8-Sep-18     |
-| [Valohai](https://valohai.com/)                                                                       | ???       | ???        | ???           | 8-Sep-18     |
-| [VScaler](https://www.vscaler.com/)                                                                   | ???       | ???        | ???           | 8-Sep-18     |
+| GPU Cloud Provider                                                                                    | K80 Price | V100 Price | Storage Price  | Last Updated |
+| ----------------------------------------------------------------------------------------------------- | --------- | ---------- | -------------- | ------------ |
+| [Google Collaboratory](https://colab.research.google.com/)                                            | Free      | -          | 15GB max       | 8-Sep-18     |
+| [Kaggle Kernels](https://www.kaggle.com/dansbecker/running-kaggle-kernels-with-a-gpu)                 | Free      | -          | 8GB max        | 8-Sep-18     |
+| [Salamander](https://salamander.ai/)                                                                  | $0.36     | $1.17      | $0.10          | 8-Sep-18     |
+| [Paperspace](https://www.paperspace.com/)                                                             | $0.59     | $2.30      | $0.10          | 8-Sep-18     |
+| [Vast.AI](https://vast.ai/)                                                                           | $0.64     | $2.30      | -              | 19-Sep-18    |
+| [Oracle Cloud](https://cloud.oracle.com/compute/gpu/features)                                         | -         | $2.25      | $0.04          | 8-Sep-18     |
+| [Spell](https://spell.run/)                                                                           | $0.27     | $3.06      | ???            | 8-Sep-18     |
+| [Crestle](https://www.crestle.com/)                                                                   | $0.59     | -          | $0.42          | 8-Sep-18     |
+| [Neptune ML](https://neptune.ml/)                                                                     | $0.64     | -          | $0.28          | 8-Sep-18     |
+| [Microsoft Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-gpu)          | $0.87     | $2.95      | $0.10          | 8-Sep-18     |
+| [LeaderGPU](https://www.leadergpu.com/)                                                               | -         | $3.00      | $0.13          | 8-Sep-18     |
+| [Amazon Web Services (AWS)](https://aws.amazon.com/ec2/instance-types/p2/)                            | $0.90     | $3.06      | $0.10          | 8-Sep-18     |
+| [DeepCognition](https://deepcognition.ai/)                                                            | $0.90     | $3.06      | ???            | 8-Sep-18     |
+| [Google Cloud Platform (GCP)](https://cloud.google.com/gpu/)                                          | $1.21     | $3.24      | $0.03          | 8-Sep-18     |
+| [FloydHub](https://www.floydhub.com/)                                                                 | $1.20     | $4.20      | 100GB included | 8-Sep-18     |
+| [IBM Cloud](https://www.ibm.com/cloud/gpu)                                                            | $2.65     | -          | ???            | 8-Sep-18     |
+| [Alibaba Cloud](https://www.alibabacloud.com/product/gpu?spm=a3c0i.11728334.1144220.1.23794a1clKeiCs) | -         | ???        | ???            | 8-Sep-18     |
+| [Lambda Labs](https://lambdalabs.com/)                                                                | -         | ???        | ???            | 8-Sep-18     |
+| [Nvidia Cloud](https://www.nvidia.com/en-us/data-center/gpu-cloud-computing/)                         | ???       | ???        | ???            | 8-Sep-18     |
+| [Riseml](https://riseml.com/)                                                                         | -         | ???        | ???            | 8-Sep-18     |
+| [Valohai](https://valohai.com/)                                                                       | ???       | ???        | ???            | 8-Sep-18     |
+| [VScaler](https://www.vscaler.com/)                                                                   | ???       | ???        | ???            | 8-Sep-18     |
 
 ### Other GPUs
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ costs low when deciding to choose their preferred platform.
 | [Google Cloud Platform (GCP)](https://cloud.google.com/gpu/)                                          | $1.21     | $3.24      | $0.03         | 8-Sep-18     |
 | [FloydHub](https://www.floydhub.com/)                                                                 | $1.20     | $4.20      | 100GB max     | 8-Sep-18     |
 | [IBM Cloud](https://www.ibm.com/cloud/gpu)                                                            | $2.65     | -          | ???           | 8-Sep-18     |
-| [Riseml](https://riseml.com/)                                                                         | -         | ???        | ???           | 8-Sep-18     |
 | [Alibaba Cloud](https://www.alibabacloud.com/product/gpu?spm=a3c0i.11728334.1144220.1.23794a1clKeiCs) | -         | ???        | ???           | 8-Sep-18     |
 | [Lambda Labs](https://lambdalabs.com/)                                                                | -         | ???        | ???           | 8-Sep-18     |
 | [Nvidia Cloud](https://www.nvidia.com/en-us/data-center/gpu-cloud-computing/)                         | ???       | ???        | ???           | 8-Sep-18     |
+| [Riseml](https://riseml.com/)                                                                         | -         | ???        | ???           | 8-Sep-18     |
 | [Valohai](https://valohai.com/)                                                                       | ???       | ???        | ???           | 8-Sep-18     |
 | [VScaler](https://www.vscaler.com/)                                                                   | ???       | ???        | ???           | 8-Sep-18     |
 
@@ -52,9 +52,9 @@ costs low when deciding to choose their preferred platform.
 | [Ovh](https://www.ovh.com/world/public-cloud/instances/prices/)                                       | -          | $1.15          | $0.09         | 8-Sep-18     |
 | [Neptune ML](https://neptune.ml/)                                                                     | $2.15      | -              | $0.28         | 8-Sep-18     |
 | [Google Cloud Platform (GCP)](https://cloud.google.com/gpu/)                                          | $2.22      | -              | $0.03         | 8-Sep-18     |
-| [IBM Cloud](https://www.ibm.com/cloud/gpu)                                                            | ???        | -              | ???           | 8-Sep-18     |
-| [Exoscale](https://exoscale.com/)                                                                     | ???        | -              | ???           | 8-Sep-18     |
 | [Alibaba Cloud](https://www.alibabacloud.com/product/gpu?spm=a3c0i.11728334.1144220.1.23794a1clKeiCs) | ???        | -              | ???           | 8-Sep-18     |
+| [Exoscale](https://exoscale.com/)                                                                     | ???        | -              | ???           | 8-Sep-18     |
+| [IBM Cloud](https://www.ibm.com/cloud/gpu)                                                            | ???        | -              | ???           | 8-Sep-18     |
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ The prices for Google Cloud Platform assume you've attached the GPUs to a
 
 Nvidia manufactures all the GPUs listed here
 
-| GPU                                                                                                                        | TFlops (double / single precision) | Manufacturer |
-| -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ------------ |
-| [K80](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/tesla-product-literature/TeslaK80-datasheet.pdf)      | 1.9 / 5.6                          | Nvidia       |
-| [V100](https://images.nvidia.com/content/technologies/volta/pdf/tesla-volta-v100-datasheet-letter-fnl-web.pdf)             | 7.8 / 125.0                        | Nvidia       |
-| [P100](https://images.nvidia.com/content/tesla/pdf/nvidia-tesla-p100-datasheet.pdf)                                        | 5.3 / 10.6                         | Nvidia       |
-| [GTX 1080](https://international.download.nvidia.com/geforce-com/international/pdfs/GeForce_GTX_1080_Whitepaper_FINAL.pdf) | 8.8 / 8.8                          | Nvidia       |
+| GPU                                                                                                                        | TFlops (double / single precision) |
+| -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| [K80](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/tesla-product-literature/TeslaK80-datasheet.pdf)      | 1.9 / 5.6                          |
+| [V100](https://images.nvidia.com/content/technologies/volta/pdf/tesla-volta-v100-datasheet-letter-fnl-web.pdf)             | 7.8 / 125.0                        |
+| [P100](https://images.nvidia.com/content/tesla/pdf/nvidia-tesla-p100-datasheet.pdf)                                        | 5.3 / 10.6                         |
+| [GTX 1080](https://international.download.nvidia.com/geforce-com/international/pdfs/GeForce_GTX_1080_Whitepaper_FINAL.pdf) | 8.8 / 8.8                          |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ costs low when deciding to choose their preferred platform.
 | [Oracle Cloud](https://cloud.oracle.com/compute/gpu/features)                                         | -         | $2.25      | $0.04         | 8-Sep-18     |
 | [Vast.AI](https://vast.ai/)                                                                           | $0.64     | $2.67      | -             | 8-Sep-18     |
 | [Spell](https://spell.run/)                                                                           | $0.27     | $3.06      | ???           | 8-Sep-18     |
-| [Crestle](https://www.crestle.com/)                                                                   | $0.59     | -          | $0.39         | 8-Sep-18     |
+| [Crestle](https://www.crestle.com/)                                                                   | $0.59     | -          | $0.42         | 8-Sep-18     |
 | [Neptune ML](https://neptune.ml/)                                                                     | $0.64     | -          | $0.28         | 8-Sep-18     |
 | [Microsoft Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-gpu)          | $0.87     | $2.95      | $0.10         | 8-Sep-18     |
 | [LeaderGPU](https://www.leadergpu.com/)                                                               | -         | $3.00      | $0.13         | 8-Sep-18     |

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ costs low when deciding to choose their preferred platform.
 
 | GPU Cloud Provider                                                                                    | K80 Price | V100 Price | Storage Price | Last Updated |
 | ----------------------------------------------------------------------------------------------------- | --------- | ---------- | ------------- | ------------ |
-| [Amazon Web Services (AWS)](https://aws.amazon.com/ec2/instance-types/p2/)                            | $0.90     | $3.06      | $0.10         | 8-Sep-18     |
-| [Google Cloud Platform (GCP)](https://cloud.google.com/gpu/)                                          | $1.21     | $3.24      | $0.03         | 8-Sep-18     |
 | [Google Collaboratory](https://colab.research.google.com/)                                            | Free      | -          | 15GB max      | 8-Sep-18     |
 | [Kaggle Kernels](https://www.kaggle.com/dansbecker/running-kaggle-kernels-with-a-gpu)                 | Free      | -          | 8GB max       | 8-Sep-18     |
 | [Salamander](https://salamander.ai/)                                                                  | $0.36     | $1.17      | $0.10         | 8-Sep-18     |
@@ -28,7 +26,9 @@ costs low when deciding to choose their preferred platform.
 | [Neptune ML](https://neptune.ml/)                                                                     | $0.64     | -          | $0.28         | 8-Sep-18     |
 | [Microsoft Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-gpu)          | $0.87     | $2.95      | $0.10         | 8-Sep-18     |
 | [LeaderGPU](https://www.leadergpu.com/)                                                               | -         | $3.00      | $0.13         | 8-Sep-18     |
+| [Amazon Web Services (AWS)](https://aws.amazon.com/ec2/instance-types/p2/)                            | $0.90     | $3.06      | $0.10         | 8-Sep-18     |
 | [DeepCognition](https://deepcognition.ai/)                                                            | $0.90     | $3.06      | ???           | 8-Sep-18     |
+| [Google Cloud Platform (GCP)](https://cloud.google.com/gpu/)                                          | $1.21     | $3.24      | $0.03         | 8-Sep-18     |
 | [FloydHub](https://www.floydhub.com/)                                                                 | $1.20     | $4.20      | 100GB max     | 8-Sep-18     |
 | [IBM Cloud](https://www.ibm.com/cloud/gpu)                                                            | $2.65     | -          | ???           | 8-Sep-18     |
 | [Riseml](https://riseml.com/)                                                                         | -         | ???        | ???           | 8-Sep-18     |

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ costs low when deciding to choose their preferred platform.
 | [Kaggle Kernels](https://www.kaggle.com/dansbecker/running-kaggle-kernels-with-a-gpu)                 | Free      | -          | 8GB max       | 8-Sep-18     |
 | [Salamander](https://salamander.ai/)                                                                  | $0.36     | $1.17      | $0.10         | 8-Sep-18     |
 | [Paperspace](https://www.paperspace.com/)                                                             | $0.59     | $2.30      | $0.10         | 8-Sep-18     |
+| [Vast.AI](https://vast.ai/)                                                                           | $0.64     | $2.30      | -             | 19-Sep-18    |
 | [Oracle Cloud](https://cloud.oracle.com/compute/gpu/features)                                         | -         | $2.25      | $0.04         | 8-Sep-18     |
-| [Vast.AI](https://vast.ai/)                                                                           | $0.64     | $2.67      | -             | 8-Sep-18     |
 | [Spell](https://spell.run/)                                                                           | $0.27     | $3.06      | ???           | 8-Sep-18     |
 | [Crestle](https://www.crestle.com/)                                                                   | $0.59     | -          | $0.42         | 8-Sep-18     |
 | [Neptune ML](https://neptune.ml/)                                                                     | $0.64     | -          | $0.28         | 8-Sep-18     |

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Google Cloud Platform gives you
 [$300 free compute credits](https://cloud.google.com/free/)
 
 Azure gives
-[100$ free compute credits](https://azure.microsoft.com/en-in/free/students/)
-for students
+[$100 free compute credits](https://azure.microsoft.com/en-in/free/students/)
+to students
 
 Google Collaboratory, Kaggle Kernels & Crestle are only for Jupyter Notebooks
 and limited to 6/12/24 hour sessions


### PR DESCRIPTION
This project is really important & helps make deep learning more accessible! This PR makes it easy for anyone to compare the listed providers at a glance. Here's a link to my patch so you can see a markdown preview: [https://github.com/ashtonsix/cloud-gpus/tree/patch-2](https://github.com/ashtonsix/cloud-gpus/tree/patch-2)

I'm obviously biased as the creator of Salamander, but I think sticking to the numbers kept me fair.

I sorted the cloud providers by the sum of their GPU prices, and used averages for missing values.

```txt
k80 avg  = $0.90
v100 avg = $2.81

Salamander    = $0.36 + $1.17 = 1.53
Paperspace    = $0.59 + $2.30 = 2.89
Oracle        = avg   + $2.25 = 3.15
Vast          = $0.64 + $2.67 = 3.31
Spell         = $0.27 + $3.06 = 3.33
Crestle       = $0.59 + avg   = 3.40
Neptune       = $0.64 + avg   = 3.45
Microsoft     = $0.87 + $2.95 = 3.82
LeaderGPU     = avg   + $3.00 = 3.90
Amazon        = $0.90 + $3.06 = 3.96
DeepCognition = $0.90 + $3.06 = 3.96
Google        = $1.21 + $3.24 = 4.45
FloydHub      = $1.20 + $4.20 = 5.40
IBM           = $2.65 + avg   = 5.46
Alibaba       = avg   + ???   = NaN
Lambda        = avg   + ???   = NaN
Nvidia        = ???   + ???   = NaN
Riseml        = avg   + ???   = NaN
Valohai       = ???   + ???   = NaN
VScaler       = ???   + ???   = NaN
```

```txt
p100 avg     = $1.58
gtx 1080 avg = $0.63

Snark         = $0.10 + avg   = 0.73
Vast          = $1.65 + $0.10 = 1.75
Oracle        = $1.28 + avg   = 1.91
Vector        = avg   + $0.51 = 2.09
LeaderGPU     = $1.50 + $0.75 = 2.25
Paperspace    = $1.72 + avg   = 2.35
Microsoft     = $2.00 + avg   = 2.63
Ovh           = avg   + $1.15 = 2.73
Neptune       = $2.15 + avg   = 2.78
Google        = $2.22 + avg   = 2.85
Alibaba       = ???   + avg   = NaN
Exoscale      = ???   + avg   = NaN
IBM           = ???   + avg   = NaN
```