### PR TITLE
Update compute credits section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cloud GPU Vendors
+# Cloud GPU Providers
 
 This repository contains information about service providers who host GPUs in
 the cloud for on-demand use for Machine Learning practitioners. This guide is
@@ -6,7 +6,7 @@ also designed to help enthusiasts, new-comers to this field and also experienced
 folks to keep a track of new updates made by all these vendors and keep their
 costs low when deciding to choose their preferred platform.
 
-## Cloud GPU Vendors
+## Cloud GPU Providers
 
 - "-" means not available
 - "???" means maybe available

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ and limited to 6 / 12 / 24 hour sessions
 
 - Paperspace gives [$15 credits](https://github.com/asiedubrempong/fastai_deeplearn_part1/blob/master/tools/paperspace.md#summary-of-charges) to fast.ai students
 
-- [Vast.AI](https://vast.ai/), [DeepCognition](https://deepcognition.ai/), [Snark AI](https://snark.ai/) & [Salamander](https://salamander.ai/) give approximately $1 credits to anyone
+- [Vast.AI](https://vast.ai/), [DeepCognition](https://deepcognition.ai/), [Snark AI](https://snark.ai/), [Salamander](https://salamander.ai/) & [Crestle](https://www.crestle.com/) give approximately $1 credits to anyone
 
 ## GPU Datasheets
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,6 @@ costs low when deciding to choose their preferred platform.
 
 ## Notes
 
-- Google Cloud Platform gives you
-[$300 free compute credits](https://cloud.google.com/free/)
-
-- Azure gives
-[$100 free compute credits](https://azure.microsoft.com/en-in/free/students/)
-to students
-
 - Google Colaboratory, Kaggle Kernels & Crestle are only for Jupyter Notebooks
 and limited to 6/12/24 hour sessions
 
@@ -73,28 +66,18 @@ and limited to 6/12/24 hour sessions
 
 - 250GB Paperspace volumes are $0.04 per GB; larger or smaller volumes cost more
 
-### Cloud Credits
+### Free Compute Credits
 
-For the benefit of beginners, we included a cloud credits section which will help beginners try these platforms for their hobby project, take it for a spin and choose the platform of their choice.
+- Google Cloud Platform gives you
+[$300 free compute credits](https://cloud.google.com/free/)
 
-Update (August 17, 2018):
-- 20$ of credit (~100 hours of GPU compute) for fastai students by Vast.ai. Check their announcement here.
+- AWS gives [$110 free compute credits](https://education.github.com/pack/) to students, in partnership with GitHub
 
-Update (August 12, 2018):
-- 2 hours of free trial on DeepCognition.
+- Azure gives
+[$100 free compute credits](https://azure.microsoft.com/en-in/free/students/)
+to students
 
-Update (August 10, 2018):
-- 75-150$ AWS credits for students with [GitHub Education Pack](https://education.github.com/pack). You would need a .edu student email address.
-
-Update (August 2, 2018):
-- 42 hours of 1080 GPU credits by Snark AI for fastai students. Promo Code available on fastai forums.
-
-Update (July 6, 2018):
-- 100 hours of GPU give away by FloydHub to the folks at RemoteML. Check out their tweet to participate.
-
-Update (May 8, 2018):
-- 15$ credit in PaperSpace for fastai students. Credit Code available here.
-
+- Paperspace gives [$15 free compute credits](https://github.com/asiedubrempong/fastai_deeplearn_part1/blob/master/tools/paperspace.md#summary-of-charges) to fast.ai students
 
 ## GPU Datasheets
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cloud GPU Vendors
 
 This guide compares on-demand GPU vendors to help Machine Learning practitioners
-pick their preferred platform. Whether your an enthusiast, newcomer or expert
+pick their preferred platform. Whether you're an enthusiast, newcomer or expert
 this guide will help you track updates and keep your costs low.
 
 ## Cloud GPU Vendors

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Cloud GPU Vendors
 
-This repository contains information about service providers who host GPUs in
-the cloud for on-demand use for Machine Learning practitioners. This guide is
-also designed to help enthusiasts, new-comers to this field and also experienced
-folks to keep a track of new updates made by all these vendors and keep their
-costs low when deciding to choose their preferred platform.
+This guide compares on-demand GPU vendors to help Machine Learning practitioners
+pick their preferred platform. Whether your an enthusiast, newcomer or expert
+this guide will help you track updates and keep your costs low.
 
 ## Cloud GPU Vendors
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cloud GPU Providers
+# Cloud GPU Vendors
 
 This repository contains information about service providers who host GPUs in
 the cloud for on-demand use for Machine Learning practitioners. This guide is
@@ -6,16 +6,16 @@ also designed to help enthusiasts, new-comers to this field and also experienced
 folks to keep a track of new updates made by all these vendors and keep their
 costs low when deciding to choose their preferred platform.
 
-## Cloud GPU Providers
+## Cloud GPU Vendors
 
 - "-" means not available
 - "???" means maybe available
 - GPU prices are per hour
 - Storage prices are per GB/month
 
-| GPU Cloud Provider                                                                                    | K80 Price | V100 Price | Storage Price  | Last Updated |
+| GPU Vendor                                                                                            | K80 Price | V100 Price | Storage Price  | Last Updated |
 | ----------------------------------------------------------------------------------------------------- | --------- | ---------- | -------------- | ------------ |
-| [Google Colaboratory](https://colab.research.google.com/)                                            | Free      | -          | 15GB max       | 8-Sep-18     |
+| [Google Colaboratory](https://colab.research.google.com/)                                             | Free      | -          | 15GB max       | 8-Sep-18     |
 | [Kaggle Kernels](https://www.kaggle.com/dansbecker/running-kaggle-kernels-with-a-gpu)                 | Free      | -          | 8GB max        | 8-Sep-18     |
 | [Salamander](https://salamander.ai/)                                                                  | $0.36     | $1.17      | $0.10          | 8-Sep-18     |
 | [Paperspace](https://www.paperspace.com/)                                                             | $0.59     | $2.30      | $0.10          | 8-Sep-18     |
@@ -40,7 +40,7 @@ costs low when deciding to choose their preferred platform.
 
 ### Other GPUs
 
-| GPU Cloud Provider                                                                                    | P100 Price | GTX 1080 Price | Storage Price | Last Updated |
+| GPU Vendor                                                                                            | P100 Price | GTX 1080 Price | Storage Price | Last Updated |
 | ----------------------------------------------------------------------------------------------------- | ---------- | -------------- | ------------- | ------------ |
 | [Snark AI](https://snark.ai/)                                                                         | $0.10      | -              | ???           | 8-Sep-18     |
 | [Vast.AI](https://vast.ai/)                                                                           | $1.65      | $0.10          | -             | 8-Sep-18     |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,6 @@ Nvidia manufactures all the GPUs listed here
 | GPU                                                                                                                        | TFlops (double / single precision) |
 | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
 | [K80](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/tesla-product-literature/TeslaK80-datasheet.pdf)      | 1.9 / 5.6                          |
-| [V100](https://images.nvidia.com/content/technologies/volta/pdf/tesla-volta-v100-datasheet-letter-fnl-web.pdf)             | 7.8 / 125.0                        |
+| [V100](https://images.nvidia.com/content/technologies/volta/pdf/tesla-volta-v100-datasheet-letter-fnl-web.pdf)             | 7.8 / 15.7                        |
 | [P100](https://images.nvidia.com/content/tesla/pdf/nvidia-tesla-p100-datasheet.pdf)                                        | 5.3 / 10.6                         |
 | [GTX 1080](https://international.download.nvidia.com/geforce-com/international/pdfs/GeForce_GTX_1080_Whitepaper_FINAL.pdf) | 8.8 / 8.8                          |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ costs low when deciding to choose their preferred platform.
 ## Notes
 
 - Google Colaboratory, Kaggle Kernels & Crestle are only for Jupyter Notebooks
-and limited to 6/12/24 hour sessions
+and limited to 6 / 12 / 24 hour sessions
 
 - The prices for Google Cloud Platform assume you've attached the GPUs to a
 "n1-standard-16" instance.

--- a/README.md
+++ b/README.md
@@ -68,14 +68,11 @@ and limited to 6/12/24 hour sessions
 
 ### Free Compute Credits
 
-- Google Cloud Platform gives you
-[$300 credits](https://cloud.google.com/free/)
+- Google Cloud Platform gives [$300 credits](https://cloud.google.com/free/) to anyone
 
 - AWS gives [$110 credits](https://education.github.com/pack/) to students, in partnership with GitHub
 
-- Azure gives
-[$100 credits](https://azure.microsoft.com/en-in/free/students/)
-to students
+- Azure gives [$100 credits](https://azure.microsoft.com/en-in/free/students/) to students
 
 - Paperspace gives [$15 credits](https://github.com/asiedubrempong/fastai_deeplearn_part1/blob/master/tools/paperspace.md#summary-of-charges) to fast.ai students
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ and limited to 6 / 12 / 24 hour sessions
 
 - Paperspace gives [$15 credits](https://github.com/asiedubrempong/fastai_deeplearn_part1/blob/master/tools/paperspace.md#summary-of-charges) to fast.ai students
 
+- [Vast.AI](https://vast.ai/), [DeepCognition](https://deepcognition.ai/), [Snark AI](https://snark.ai/) & [Salamander](https://salamander.ai/) give approximately $1 credits to anyone
+
 ## GPU Datasheets
 
 Nvidia manufactures all the GPUs listed here

--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ and limited to 6/12/24 hour sessions
 ### Free Compute Credits
 
 - Google Cloud Platform gives you
-[$300 free compute credits](https://cloud.google.com/free/)
+[$300 credits](https://cloud.google.com/free/)
 
-- AWS gives [$110 free compute credits](https://education.github.com/pack/) to students, in partnership with GitHub
+- AWS gives [$110 credits](https://education.github.com/pack/) to students, in partnership with GitHub
 
 - Azure gives
-[$100 free compute credits](https://azure.microsoft.com/en-in/free/students/)
+[$100 credits](https://azure.microsoft.com/en-in/free/students/)
 to students
 
-- Paperspace gives [$15 free compute credits](https://github.com/asiedubrempong/fastai_deeplearn_part1/blob/master/tools/paperspace.md#summary-of-charges) to fast.ai students
+- Paperspace gives [$15 credits](https://github.com/asiedubrempong/fastai_deeplearn_part1/blob/master/tools/paperspace.md#summary-of-charges) to fast.ai students
 
 ## GPU Datasheets
 


### PR DESCRIPTION
I think the compute credits section can be improved:

Group the offers together, and sort by value / exclusivity.

Improve ability to scan visually by starting each line with provider name, consistently linking on the amount & removing distracting dates.

Only include Google Cloud, AWS, Azure & Paperspace. The other offers are rubbish or expired. We should only highlight offers that have practical value.

* FloydHub only gave credits to 3 randomly selected users
* Vast.ai lowered their giveaway to $1 [[link](http://forums.fast.ai/t/vast-ai-easy-docker-based-peer-gpu-rental-training-costs-3x-to-5x-less/20919)]
* DeepCognition only gives 2 hours
* snark.ai is obtuse & after signing up via referral I only received 10.5 hours, not 42 hours (worth $1)

Don't think I'm biased here, as Salamander also gives new users $1 and similarly isn't worth publicising here.

I created a PR into your PR. Preview [here](https://github.com/ashtonsix/cloud-gpus/tree/patch-3).